### PR TITLE
Scope.bb.basket.settings.requires deal

### DIFF
--- a/src/core/javascripts/controllers/basket.js.coffee
+++ b/src/core/javascripts/controllers/basket.js.coffee
@@ -156,9 +156,7 @@ angular.module('BB.Controllers').controller 'BasketList', ($scope, $attrs, $root
         item.reserve_without_questions = $scope.bb.reserve_without_questions
       basket.setSettings($scope.bb.basket.settings)
       $scope.setBasket(basket)
-      $scope.items = $scope.bb.basket.items
-      console.log "$scope.deal_code => " + $scope.deal_code
-      console.log "$scope.bb.basket.hasDeal() => " + $scope.bb.basket.hasDeal()
+      $scope.items = $scope.bb.basket.items     
       $scope.deal_code = null
     , (err) ->
       if err and err.data and err.data.error

--- a/src/core/javascripts/controllers/basket.js.coffee
+++ b/src/core/javascripts/controllers/basket.js.coffee
@@ -60,11 +60,7 @@ angular.module('BB.Directives').directive 'bbBasketList', () ->
   controller : 'BasketList'
 
 
-<<<<<<< HEAD
-angular.module('BB.Controllers').controller 'BasketList', ($scope, $attrs, $rootScope, BasketService, $q, AlertService, ErrorService, FormDataStoreService, LoginService) ->
-=======
-angular.module('BB.Controllers').controller 'BasketList', ($scope,  $rootScope, BasketService, $q, AlertService, FormDataStoreService, LoginService) ->
->>>>>>> d79dea5b1827416a6f47aa874ee4ae9089a87646
+angular.module('BB.Controllers').controller 'BasketList', ($scope, $attrs, $rootScope, BasketService, $q, AlertService, FormDataStoreService, LoginService) ->
   $scope.controller = "public.controllers.BasketList"
   $scope.setUsingBasket(true)
   $scope.items = $scope.bb.basket.items
@@ -215,3 +211,4 @@ angular.module('BB.Controllers').controller 'BasketList', ($scope,  $rootScope, 
     else
       AlertService.raise('EMPTY_BASKET_FOR_CHECKOUT')
       return false
+      

--- a/src/core/javascripts/services/error.js.coffee
+++ b/src/core/javascripts/services/error.js.coffee
@@ -72,6 +72,13 @@ angular.module('BB.Services').factory 'ErrorService', (SettingsService) ->
       msg: 'Unfortunately, the maximum number of tickets per person has been reached.'
     },
     {
+      key: 'GIFT_CERTIFICATE_REQUIRED',
+      type: 'warning',
+      title: '',
+      persist: true,
+      msg: 'A valid Gift Certificate is required to proceed with this booking'
+    },
+    {
       key: 'TIME_SLOT_NOT_SELECTED',
       type: 'warning', 
       title: '',


### PR DESCRIPTION
 Added $attrs dependancy to controller BasketList so that requires_deal can be assigned to bb.basket.settings using bb-basket-list='{requires_deal:true}'.

Updated setReady() so it now fails if settings.requires_deal is true and hasDeal() returns false (do not proceed to checkout).

Added a new error object to errors.js.coffee - "GIFT_CERTIFICATE_REQUIRED"

Resolved merge conflict by removing ErrorService dependancy and adding $attrs dependancy from/to BasketList controller and using the new AlertService.raise(<error_key>) method for "GIFT_CERTIFICATE_NOT_FOUND"