### PR TITLE
HOTFIX - default angular admin journey broken

### DIFF
--- a/src/core/javascripts/controllers/base.js.coffee
+++ b/src/core/javascripts/controllers/base.js.coffee
@@ -802,7 +802,7 @@ angular.module('BB.Controllers').controller 'BBCtrl', ($scope, $location,
       return if $scope.setPageRoute($rootScope.Route.Duration)
       return $scope.showPage('duration_list')
     else if ($scope.bb.current_item.days_link && !$scope.bb.current_item.date && !$scope.bb.current_item.event? && !$scope.bb.current_item.deal)
-      if $scope.bb.company.$has('slots')
+      if $scope.bb.company.$has('availability_slots')
         return if $scope.setPageRoute($rootScope.Route.Slot)
         return $scope.showPage('slot_list')
       else


### PR DESCRIPTION
Add availability-slots to avoid checking slots when its not needed
with reference to this: https://github.com/Glenn/bookingbug/pull/786