### PR TITLE
Updated SDK to record skipped steps:

### DIFF
--- a/src/core/javascripts/controllers/base.js.coffee
+++ b/src/core/javascripts/controllers/base.js.coffee
@@ -1144,10 +1144,32 @@ angular.module('BB.Controllers').controller 'BBCtrl', ($scope, $location,
         $scope.bb.allSteps[$scope.bb.current_step-1].active = true
 
 
-  $scope.loadPreviousStep = (number_of_steps_to_go_back) ->
-    number_of_steps_to_go_back = number_of_steps_to_go_back or 1
-    step = $scope.bb.current_step - number_of_steps_to_go_back
-    $scope.loadStep(step)
+  ###**
+  * @ngdoc method
+  * @name loadPreviousStep
+  * @methodOf BB.Directives:bbWidget
+  * @description
+  * Loads the previous unskipped step
+  *
+  * @param {object} steps_to_go_back The number of steps to go back
+  ###
+  $scope.loadPreviousStep = (steps_to_go_back) ->
+
+    steps_to_go_back = steps_to_go_back or 1
+
+    past_steps = _.without($scope.bb.steps, _.last($scope.bb.steps))
+
+    # find the last unskipped step and load that (whilst respecting
+    # the number of steps to go back)
+    step_count = 0
+    while step_count < steps_to_go_back
+      last_step = past_steps.pop()
+      if !last_step.skipped
+        step_to_load = last_step.number
+        step_count++
+
+    $scope.loadStep(step_to_load)
+
 
   $scope.loadStepByPageName = (page_name) ->
     for step in $scope.bb.allSteps
@@ -1172,12 +1194,15 @@ angular.module('BB.Controllers').controller 'BBCtrl', ($scope, $location,
     $scope.bb.setBasicRoute(routes)
 
 
-  # record the page right now
-  # this look s the a record breadcrumb step path - and also helps keep updated passed and current steps
-
-
+  ###**
+  * @ngdoc method
+  * @name skipThisStep
+  * @methodOf BB.Directives:bbWidget
+  * @description
+  * Marks the current step as skipped
+  ###
   $scope.skipThisStep = () ->
-    $scope.bb.current_step -= 1
+    $scope.bb.steps[$scope.bb.steps.length - 1].skipped = true
 
 
   #############################################################

--- a/src/core/javascripts/controllers/base.js.coffee
+++ b/src/core/javascripts/controllers/base.js.coffee
@@ -1168,7 +1168,7 @@ angular.module('BB.Controllers').controller 'BBCtrl', ($scope, $location,
         step_to_load = last_step.number
         step_count++
 
-    $scope.loadStep(step_to_load)
+    $scope.loadStep(step_to_load) if step_to_load
 
 
   $scope.loadStepByPageName = (page_name) ->

--- a/src/core/javascripts/controllers/item_details.js.coffee
+++ b/src/core/javascripts/controllers/item_details.js.coffee
@@ -70,7 +70,7 @@ angular.module('BB.Controllers').controller 'ItemDetails', ($scope, $attrs, $roo
 
   $rootScope.connection_started.then () ->
     $scope.loadItem($scope.bb.current_item) if !confirming
-  , (err) ->  $scope.setLoadedAndShowError($scope, err, 'Sorry, something went wrong')
+  , (err) -> $scope.setLoadedAndShowError($scope, err, 'Sorry, something went wrong')
 
   ###**
   * @ngdoc method

--- a/src/core/javascripts/controllers/service_list.js.coffee
+++ b/src/core/javascripts/controllers/service_list.js.coffee
@@ -95,7 +95,6 @@ angular.module('BB.Controllers').controller 'ServiceList',($scope, $rootScope, $
       $scope.service = null
 
     ppromise = comp.getServicesPromise()
-    @skipped = false
     ppromise.then (items) =>
       if $scope.hide_disabled
         # this might happen to ahve been an admin api call which would include disabled services - and we migth to hide them
@@ -118,12 +117,9 @@ angular.module('BB.Controllers').controller 'ServiceList',($scope, $rootScope, $
 
       # if there's only one service and single pick hasn't been enabled, 
       # automatically select the service.
-      if (items.length is 1 && !$scope.allowSinglePick)
-        if !$scope.selectItem(items[0], $scope.nextRoute )
+      if (items.length is 1 and !$scope.allowSinglePick)
+        if !$scope.selectItem(items[0], $scope.nextRoute, {skip_step: true})
           setServiceItem items
-        else if !@skipped
-          $scope.skipThisStep()
-          @skipped = true          
       else
         setServiceItem items
 
@@ -170,11 +166,8 @@ angular.module('BB.Controllers').controller 'ServiceList',($scope, $rootScope, $
         $scope.bookable_items = items
         
         if services.length is 1 and !$scope.allowSinglePick
-          if !$scope.selectItem(services[0], $scope.nextRoute )
+          if !$scope.selectItem(services[0], $scope.nextRoute, {skip_step: true})
             setServiceItem services
-          else if !@skipped
-            $scope.skipThisStep()
-            @skipped = true  
         else
           # The ServiceModel is more relevant than the BookableItem when price and duration needs to be listed in the view pages. 
           setServiceItem services
@@ -182,6 +175,7 @@ angular.module('BB.Controllers').controller 'ServiceList',($scope, $rootScope, $
         $scope.setLoaded($scope)
       , (err) ->  
         $scope.setLoadedAndShowError($scope, err, 'Sorry, something went wrong')
+  
   
   # set the service item so the correct item is displayed in the dropdown menu.
   # without doing this the menu will default to 'please select'
@@ -204,7 +198,7 @@ angular.module('BB.Controllers').controller 'ServiceList',($scope, $rootScope, $
   * @param {object} item The Service or BookableItem to select
   * @param {string=} route A specific route to load
   ###
-  $scope.selectItem = (item, route) =>
+  $scope.selectItem = (item, route, options={}) =>
     if $scope.routed
       return true
 
@@ -213,10 +207,12 @@ angular.module('BB.Controllers').controller 'ServiceList',($scope, $rootScope, $
       return false
     else if item.is_event_group
       $scope.booking_item.setEventGroup(item)
+      $scope.skipThisStep() if options.skip_step
       $scope.decideNextPage(route)
       $scope.routed = true
     else
       $scope.booking_item.setService(item)
+      $scope.skipThisStep() if options.skip_step
       $scope.decideNextPage(route)
       $scope.routed = true
       return true

--- a/src/core/javascripts/services/widget.js.coffee
+++ b/src/core/javascripts/services/widget.js.coffee
@@ -163,7 +163,7 @@ angular.module('BB.Models').factory "BBWidget", ($q, BBModel, BasketService, $ur
     * @name recordCurrentPage
     * @methodOf BB.Models:BBWidget
     * @description
-    * Record current page
+    * Records the current page and determines the current step from either the predefined steps or the steps that have been passed already
     *
     * @returns {string} The returned record step
     ###
@@ -171,7 +171,7 @@ angular.module('BB.Models').factory "BBWidget", ($q, BBModel, BasketService, $ur
       if !@current_step
         @current_step = 0
       match = false
-      # can we find a match for this step against either previous or existing steps ?
+      # can we find a match for this step against either previous or existing steps?
       # first check the pre-defined steps
       if @allSteps
         for step in @allSteps
@@ -200,7 +200,7 @@ angular.module('BB.Models').factory "BBWidget", ($q, BBModel, BasketService, $ur
 
     ###**
     * @ngdoc method
-    * @name recordCurrentPage
+    * @name recordStep
     * @methodOf BB.Models:BBWidget
     * @description
     * Record step in according of step and title parameters. Calculate percentile complete
@@ -215,7 +215,7 @@ angular.module('BB.Models').factory "BBWidget", ($q, BBModel, BasketService, $ur
         number: step, 
         title: title,
         stacked_length: @stacked_items.length
-        }
+      }
 
       BreadcrumbService.setCurrentStep(step)
 


### PR DESCRIPTION
- Updated loadPreviousStep() to take account of skipped steps so it loads the correct step when going back
- Updated skipThisStep() to mark the current step as skipped - manipulating current_step had no affect as recordCurrentPage() in the widget service always overrode it as a new page is loaded
- Updated bbResources directive with allow_single_pick option akin to bbServices
- Refactored bbServices to mark step as skipped before it routes to the next page