### PR TITLE
amended setDuration to honour duration price changes

### DIFF
--- a/src/core/javascripts/models/basket_item.js.coffee
+++ b/src/core/javascripts/models/basket_item.js.coffee
@@ -560,12 +560,12 @@ angular.module('BB.Models').factory "BasketItemModel",
       @duration = dur
       if @service
         @base_price = @service.getPriceByDuration(dur)
-      if @time && @time.price
+      else if @time && @time.price
         @base_price = @time.price
-      if @price && (@price != @base_price) 
-        @setPrice(@price)
-      else 
-         @setPrice(@base_price)
+      else if @price
+        @base_price = @price
+
+      @setPrice(@base_price)
 
     ###**
     * @ngdoc method


### PR DESCRIPTION
The bit `@base_price = @service.getPriceByDuration(dur)` was working correctly and setting the price as expected when the booking duration changed (i.e. when the duration doubles, the price doubles)

But the following lines would then undo that work and change the price back to the original price, before multiplication.

I've added some `else if`s to sort that out.