### PR TITLE
[CAPONE-137] title set check step exists

### DIFF
--- a/src/core/javascripts/controllers/base.js.coffee
+++ b/src/core/javascripts/controllers/base.js.coffee
@@ -1137,7 +1137,7 @@ angular.module('BB.Controllers').controller 'BBCtrl', ($scope, $location,
 
   # conditionally set the title of the current step - if it doesn't have one
   $scope.checkStepTitle = (title) ->
-    if !$scope.bb.steps[$scope.bb.current_step-1].title
+    if $scope.bb.steps[$scope.bb.current_step-1] and !$scope.bb.steps[$scope.bb.current_step-1].title
       $scope.setStepTitle(title)
 
   # reload a step


### PR DESCRIPTION
Now that we clear the steps on checkout it can throw a air-break error if we dont have that step. This should fix that. 