### PR TITLE
[CAPONE] airbrake title fix 2.0

### DIFF
--- a/src/core/javascripts/controllers/base.js.coffee
+++ b/src/core/javascripts/controllers/base.js.coffee
@@ -1130,7 +1130,7 @@ angular.module('BB.Controllers').controller 'BBCtrl', ($scope, $location,
   $scope.getCurrentStepTitle = ->
     steps = $scope.bb.steps
 
-    if !_.compact(steps).length
+    if !_.compact(steps).length or steps.length == 1 and steps[0].number != $scope.bb.current_step
       steps = $scope.bb.allSteps
 
     if $scope.bb.current_step


### PR DESCRIPTION
So the current step is not representative of the step then we set it to all steps so it gets the correct title.