### PR TITLE
[ORIENTAL-81] Removed the 4th view option as this is not necessary,  …

### DIFF
--- a/src/admin-booking/javascripts/services/general_options.js.coffee
+++ b/src/admin-booking/javascripts/services/general_options.js.coffee
@@ -13,7 +13,7 @@
 * @name GeneralOptionsProvider
 *
 * @description
-* Provider 
+* Provider
 *
 * @example
   <example>
@@ -26,7 +26,10 @@ angular.module('BBAdminBooking').provider 'GeneralOptions', [ ->
   # This list of default options is meant to grow
   options = {
     twelve_hour_format : false,
-    calendar_minute_step: 10
+    calendar_minute_step: 10,
+    calendar_min_time: "09:00",
+    calendar_max_time: "18:00",
+    calendar_slot_duration: 5
   }
 
   @setOption = (option, value) ->

--- a/src/admin-dashboard/javascripts/directives/resource_calendar.js.coffee
+++ b/src/admin-dashboard/javascripts/directives/resource_calendar.js.coffee
@@ -5,7 +5,7 @@ angular.module('BBAdminDashboard').directive 'bbResourceCalendar', (
     $timeout, $compile, $templateCache, BookingCollections, PrePostTime,
     AdminScheduleService, $filter) ->
 
-  controller = ($scope, $attrs, BBAssets, ProcessAssetsFilter, $state) ->
+  controller = ($scope, $attrs, BBAssets, ProcessAssetsFilter, $state, GeneralOptions) ->
 
     filters = {
       requestedAssets : ProcessAssetsFilter($state.params.assets)
@@ -89,11 +89,14 @@ angular.module('BBAdminDashboard').directive 'bbResourceCalendar', (
     else
       800
 
-    if not $scope.options.minTime?
-      $scope.options.minTime = "09:00"
+    if not $scope.options.min_time?
+      $scope.options.min_time = GeneralOptions.calendar_min_time
 
-    if not $scope.options.maxTime?
-      $scope.options.maxTime = "18:00"
+    if not $scope.options.max_time?
+      $scope.options.max_time = GeneralOptions.calendar_max_time
+
+    if not $scope.options.cal_slot_duration?
+      $scope.options.cal_slot_duration = GeneralOptions.calendar_slot_duration
 
     # @todo REPLACE ALL THIS WITH VAIABLES FROM THE GeneralOptions Service
     $scope.uiCalOptions =
@@ -101,8 +104,8 @@ angular.module('BBAdminDashboard').directive 'bbResourceCalendar', (
         schedulerLicenseKey: '0598149132-fcs-1443104297'
         eventStartEditable: true
         eventDurationEditable: false
-        minTime: $scope.options.minTime
-        maxTime: $scope.options.maxTime
+        minTime: $scope.options.min_time
+        maxTime: $scope.options.max_time
         height: height
         header:
           left: 'today,prev,next'
@@ -111,24 +114,17 @@ angular.module('BBAdminDashboard').directive 'bbResourceCalendar', (
         defaultView: 'timelineDay'
         views:
           agendaWeek:
-            slotDuration: $scope.options.slotDuration || "00:05"
+            slotDuration: $filter('minutesToString')($scope.options.cal_slot_duration)
             buttonText: 'Week'
             groupByDateAndResource: false
           month:
             eventLimit: 5
             buttonText: 'Month'
           timelineDay:
-            slotDuration: $scope.options.slotDuration || "00:05"
+            slotDuration: $filter('minutesToString')($scope.options.cal_slot_duration)
             eventOverlap: false
             slotWidth: 25
-            buttonText: 'Day (5m)'
-            resourceAreaWidth: '18%'
-          timelineDayThirty:
-            type: 'timeline'
-            slotDuration: "00:30"
-            eventOverlap: false
-            slotWidth: 25
-            buttonText: 'Day (30m)'
+            buttonText: 'Day (' + $scope.options.cal_slot_duration + 'm)'
             resourceAreaWidth: '18%'
         resourceLabelText: 'Staff'
         selectable: true
@@ -172,15 +168,15 @@ angular.module('BBAdminDashboard').directive 'bbResourceCalendar', (
 
           if Math.abs(start.diff(end, 'days')) > 0
             end.subtract(1,'days')
-            end = setTimeToMoment(end,$scope.options.maxTime)
+            end = setTimeToMoment(end,$scope.options.max_time)
 
           view.calendar.unselect()
           rid = null
           rid = resource.id if resource
           $scope.getCompanyPromise().then (company) ->
             AdminBookingPopup.open
-              min_date: setTimeToMoment(start,$scope.options.minTime)
-              max_date: setTimeToMoment(end,$scope.options.maxTime)
+              min_date: setTimeToMoment(start,$scope.options.min_time)
+              max_date: setTimeToMoment(end,$scope.options.max_time)
               from_datetime: start
               to_datetime: end
               item_defaults:

--- a/src/admin-dashboard/javascripts/filter/minute_to_string.js.coffee
+++ b/src/admin-dashboard/javascripts/filter/minute_to_string.js.coffee
@@ -1,0 +1,9 @@
+###
+* @ngdoc filter
+* @name BB.Filters.filter:minutesToString
+* @description
+* Converts a number to the desired format (default is hour minute(HH:mm))
+###
+angular.module('BB.Filters').filter 'minutesToString', ->
+  (minutes, format = 'HH:mm') ->
+    return moment(moment.duration(minutes, 'minutes')._data).format(format)


### PR DESCRIPTION
…then set the default view via the GeneralOptions, this then can be set for each project either by overriding this in the config block or as an option for bbResourceCalendar. Added a filter to change numbers into a desired format, this is used to format the cal_slot_duration number and may be useful throughout the SDK. Lastly changed the variable names for minTime and maxTime that are relevant to BB so that they match the BB naming conventions for variables and moved their defaults into the GeneralOptions.