### PR TITLE
[ORIENTAL-69] extend #labelAssembly for blocked events

### DIFF
--- a/src/admin-dashboard/javascripts/directives/resource_calendar.js.coffee
+++ b/src/admin-dashboard/javascripts/directives/resource_calendar.js.coffee
@@ -50,14 +50,18 @@ angular.module('BBAdminDashboard').directive 'bbResourceCalendar', (
 
     labelAssembly = (event)->
       # if labelAssembler attribute not defined or event is "block" return the normal title
-      return event.title if not $scope.labelAssembler? || event.status == 3
+      return event.title if (not $scope.labelAssembler? and event.status != 3) || (not $scope.blockLabelAssembler? and event.status == 3)
       # if label-assembler attr is provided it needs to be inline with the following RegExp
       #   ex: label-assembler='{service_name} - {client_name} - {created_at|date:shortTime}'
       # everything outside  {} will remain as is, inside the {} the first param (required) is the property name
       # second after the '|' (optional) is the filter and third after the ':' (optional) are the options for filter
       myRe = new RegExp("\\{([a-zA-z_-]+)\\|?([a-zA-z_-]+)?:?([a-zA-z0-9{}_-]+)?\\}", "g")
 
-      label = $scope.labelAssembler
+      if event.status == 3
+        label = $scope.blockLabelAssembler
+      else
+        label = $scope.labelAssembler
+
       for match,index in $scope.labelAssembler.match myRe
         parts = match.split(myRe)
         # Remove unnecessary empty properties of the array (first/last)
@@ -354,4 +358,5 @@ angular.module('BBAdminDashboard').directive 'bbResourceCalendar', (
     templateUrl: 'resource_calendar_main.html'
     scope :
       labelAssembler : '@'
+      blockLabelAssembler: '@'
   }


### PR DESCRIPTION
add $scope.blockLabelAssembler to bbResourceCalendar directive to mark blocked events with the description "Blocked" for easier visual distinction of blocked events and ultimately improved user experience. 