### PR TITLE
Add bootstrap-sass to bower, because the current bower dependency of …

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,6 +38,7 @@
     "angular-spectrum-colorpicker": "~1.4.2",
     "angular-dragdrop": "~1.0.11",
     "bootstrap-sass-official": "~3.3.1",
+    "bootstrap-sass": "~3.3.6",
     "fontawesome": "~4.2.0",
     "ng-idle": "~0.3.5",
     "underscore": "~1.7.0",


### PR DESCRIPTION
…bootstrap-sass-official is not the official bootstrap-sass.