### PR TITLE
PR-ref-changes

### DIFF
--- a/src/core/javascripts/controllers/base.js.coffee
+++ b/src/core/javascripts/controllers/base.js.coffee
@@ -919,6 +919,9 @@ angular.module('BB.Controllers').controller 'BBCtrl', ($scope, $location,
 
       # restore the current item using the ref
       current_item = _.find basket.items, (item) -> item.ref is current_item_ref
+      # use last item if there is no ref
+      current_item = _.last basket.items if !current_item
+
       $scope.setBasketItem(current_item)
 
       # check if item has been added to the basket


### PR DESCRIPTION
This change is so that you use the last item in the basket as the current_item if there is not a current already set by the ref. This will prevent some odd restoring especially when the back button is triggered.