### PR TITLE
Handle display timezone different from system timezone

### DIFF
--- a/src/core/javascripts/services/datetime_utilities.js.coffee
+++ b/src/core/javascripts/services/datetime_utilities.js.coffee
@@ -10,9 +10,7 @@ angular.module('BB.Services').factory "DateTimeUtilitiesService", (SettingsServi
   # a valid moment object
   convertTimeSlotToMoment: (date, time_slot) ->
     return unless date and moment.isMoment(date) and time_slot
-    datetime = moment()
-    if SettingsService.getDisplayTimeZone() != SettingsService.getTimeZone()
-      datetime = datetime.tz(SettingsService.getTimeZone())
+    datetime = moment().tz(SettingsService.getTimeZone())
     val = parseInt(time_slot.time)
     hours = parseInt(val / 60)
     mins = val % 60

--- a/src/public-booking/templates/_week_calendar.html
+++ b/src/public-booking/templates/_week_calendar.html
@@ -127,8 +127,8 @@
             </button>
           </span>
           <h3 class="day-heading col-xs-8 col-sm-12">
-            <span class="visible-xs">{{day.date | datetime: "ddd"}} <strong>{{day.date | datetime: "D"}} </strong>{{day.date | datetime: "MMM"}}</span>
-            <span class="hidden-xs">{{day.date | datetime: "ddd"}} <strong>{{day.date | datetime: "D"}} </strong></span>
+            <span class="visible-xs">{{day.date.format("ddd")} <strong>{{day.date.format("D")} </strong>{{day.date.format("MMM")}</span>
+            <span class="hidden-xs">{{day.date.format("ddd")} <strong>{{day.date.format("D")} </strong></span>
           </h3>
           <span class="col-xs-2 next visible-xs">
             <button type="button" class="btn btn-icon visible-xs pull-right" ng-click="add('days', 1)" ng-disabled="!isLoaded">


### PR DESCRIPTION
- Adjust to company timezone even if displayTimeZone == company time zone as not adjusting causes shifts if you're adjusting to company time zone from another time zone.
- Don't adjust calendar headers one day back if the display time zone is west of the system.
