### PR TITLE
ClientModel - strip off the leading zero in fullMobile.

### DIFF
--- a/src/core/javascripts/models/client.js.coffee
+++ b/src/core/javascripts/models/client.js.coffee
@@ -319,7 +319,7 @@ angular.module('BB.Models').factory "ClientModel", ($q, BBModel, BaseModel,
     fullMobile: ->
       return if !@mobile
       return @mobile if !@mobile_prefix
-      return "+" + @mobile_prefix + @mobile
+      return "+" + @mobile_prefix + if @mobile.substr(0,1) is '0' then @mobile.substr(1) else @mobile
 
     ###**
     * @ngdoc method


### PR DESCRIPTION
Strip off the leading zero in `fullMobile`.
=============

**Change Notes:** Modified ClientModel to strip off the leading zero in `fullMobile`.

<h3 align="center">
Before:  implementing changes :
</h3>
<h5>
Screencast :
</h5>
**Note:** notice how the zero is being added after the prefix(+44) in the 'Mobile' field under 'Bennnny'.
![](https://i.gyazo.com/cd8b8e9793f3339c8c71121ee93bbd83.gif)
<h5>
Screenshot :
</h5>
**Note:** notice how the zero is being added after the prefix(+44) in the 'Mobile' field under 'Bennnny'.
![](https://i.gyazo.com/b4de4da4eb63f8e1163a3bf730a39230.png)

<h3 align="center">
After:  implementing changes :
</h3>
**Note:** notice how the zero is now not added after the prefix(+44) in the 'Mobile' field under 'Bennnny'.
![](https://i.gyazo.com/5ac01ea9b8f59d125b9bdc61b4597453.gif)