### PR TITLE
fixed greying-out unavailable time slots on calendar page.

### DIFF
--- a/src/public-booking/stylesheets/_calendar.scss
+++ b/src/public-booking/stylesheets/_calendar.scss
@@ -118,7 +118,7 @@
     margin-bottom: 10px;
     font-size: $font-size-small;
     // font-size: 0.9rem;
-  } 
+  }
 
   .selected-time {
     display: block;
@@ -152,12 +152,12 @@
     background-color: $gray-light;
     color: #FFF;
   }
-  .panel-group .selected  .panel{
+  .panel-group .selected .panel{
     background-color: $gray-light;
     color: #FFF;
   }
- 
- 
+
+
   .panel-default.expanded > .panel-heading {
     padding-bottom: 5px;
   }
@@ -174,6 +174,27 @@
     }
     .panel-title {
       color: $bb-gray;
+    }
+  }
+
+  // disabled panel when using bb-accordion-group
+  [bb-accordion-group] {
+    &[disabled] {
+      & > {
+        .panel-default, .panel.expanded {
+          background: none;
+
+          .panel-heading {
+            cursor: default;
+          }
+          .panel-collapse {
+            display: none;
+          }
+          .panel-title {
+            color: $bb-gray;
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fixed greying-out unavailable slots on the calendar page.

## Screenshot before fix:
_(Note how the unavailable time slots are not greyed-out)_

![](https://i.gyazo.com/1c2b47e5465585d615f1666c384475e5.png)

## Screenshot with changes implemented:
_(Note how the unavailable time slots are now greyed-out)_

![](https://i.gyazo.com/5c69f048ef9839aa913e37cb59de043e.png)