### PR TITLE
IMPL-266

### DIFF
--- a/src/admin-dashboard/javascripts/core/services/busy_service.js.coffee
+++ b/src/admin-dashboard/javascripts/core/services/busy_service.js.coffee
@@ -50,7 +50,10 @@ angular.module('BBAdminDashboard').factory "BusyService", [
       $log.warn(err, error_string)
       @setLoaded(scope)
       if err.status is 409
-        AlertService.danger(ErrorService.getError('ITEM_NO_LONGER_AVAILABLE'))
+        if err.data.error is 'Rule checking failed'
+          AlertService.danger(ErrorService.createCustomError(err.data.message))
+        else
+          AlertService.danger(ErrorService.getError('ITEM_NO_LONGER_AVAILABLE'))
       else if err.data and err.data.error is "Number of Bookings exceeds the maximum"
         AlertService.danger(ErrorService.getError('MAXIMUM_TICKETS'))
       else

--- a/src/core/javascripts/services/error.js.coffee
+++ b/src/core/javascripts/services/error.js.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-angular.module('BB.Services').factory 'ErrorService', (GeneralOptions) ->
+angular.module('BB.Services').factory 'ErrorService', (GeneralOptions, $translate) ->
 
   alerts = [
     {
@@ -299,13 +299,20 @@ angular.module('BB.Services').factory 'ErrorService', (GeneralOptions) ->
     }
   ]
 
-  getError: (key) ->
+  ###*
+  # @param {String} msg
+  # @returns {{msg: String}}
+  ###
+  createCustomError = (msg) ->
+    return {msg: msg}
+
+  getError = (key) ->
     error = _.findWhere(alerts, {key: key})
     error.persist = true
     translate = GeneralOptions.use_i18n
     # if i18n enabled, return the translation key
     if error and translate
-      return {msg: "ERROR.#{key}"}
+      return {msg: $translate.instant('ERROR.' + key)}
     # else return the error object
     else if error and !translate
       return error
@@ -316,14 +323,20 @@ angular.module('BB.Services').factory 'ErrorService', (GeneralOptions) ->
       return alerts[0]
 
 
-  getAlert: (key) ->
+  getAlert = (key) ->
     alert = _.findWhere(alerts, {key: key})
     translate = GeneralOptions.use_i18n
     # if i18n enabled, return the translation key
     if alert and translate
-      return {msg: "ALERT.#{key}"}
+      return {msg: $translate.instant('ALERT.' + key)}
     else if alert and !translate
       return alert
     else
       return null
+
+  return {
+    createCustomError: createCustomError
+    getAlert: getAlert
+    getError: getError
+  }
 


### PR DESCRIPTION
usage example:
when client business rules are not met server returns 409 with 'error' = 'Rule checking failed'
and 'message' = Item failed to pass business rules test (Limit upcoming bookings per customer)
'message' in this case is dynamic (client specific error) and has to be passed as it is to interface
