### PR TITLE
[IMPL-1328] fix skip to next step on person_list and resource_list(same as for version 1)

### DIFF
--- a/src/core/javascripts/controllers/person_list.js.coffee
+++ b/src/core/javascripts/controllers/person_list.js.coffee
@@ -110,16 +110,16 @@ angular.module('BB.Controllers').controller 'PersonList', ($scope, $rootScope,
             $scope.person = i.item if $scope.bb.current_item.settings.person isnt -1
             $scope.selected_bookable_items = [i]
 
-        # if the person has been passed into item_defaults, skip to next step
-        # OR if there's only 1 person and combine resources/staff has been turned on, auto select the person
-        if ($scope.bb.item_defaults.person) or (items.length is 1 and $scope.bb.company.settings and $scope.bb.company.settings.merge_people)
-          selected_item = items[0]
-          if items.length isnt 1
-            selected_item = getItemFromPerson($scope.bb.item_defaults.person)
-          if !$scope.selectItem(selected_item, $scope.nextRoute, {skip_step: true})
-            setPerson people
-            $scope.bookable_items = items
-            $scope.selected_bookable_items = items
+        # if there's only 1 person and combine resources/staff has been turned on, auto select the person
+        # OR if the person has been passed into item_defaults, skip to next step
+        if (items.length is 1 and $scope.bb.company.settings and $scope.bb.company.settings.merge_people)
+          person = items[0]
+        if $scope.bb.item_defaults.person
+          person = $scope.bb.item_defaults.person
+        if person and !$scope.selectItem(person, $scope.nextRoute, {skip_step: true})
+          setPerson people
+          $scope.bookable_items = items
+          $scope.selected_bookable_items = items
         else
           setPerson people
           $scope.bookable_items = items

--- a/src/core/javascripts/controllers/person_list.js.coffee
+++ b/src/core/javascripts/controllers/person_list.js.coffee
@@ -110,14 +110,13 @@ angular.module('BB.Controllers').controller 'PersonList', ($scope, $rootScope,
             $scope.person = i.item if $scope.bb.current_item.settings.person isnt -1
             $scope.selected_bookable_items = [i]
 
-        # if there's only 1 person and combine resources/staff has been turned on, auto select the person
-        if (items.length is 1 and $scope.bb.company.settings and $scope.bb.company.settings.merge_people)
-          if !$scope.selectItem(items[0], $scope.nextRoute )
+        # if the person has been passed into item_defaults via query string, skip to next step
+        # OR if there's only 1 person and combine resources/staff has been turned on, auto select the person
+        if ($scope.bb.item_defaults.person) or (items.length is 1 and $scope.bb.company.settings and $scope.bb.company.settings.merge_people)
+          if !$scope.selectItem(items[0], $scope.nextRoute, {skip_step: true})
             setPerson people
             $scope.bookable_items = items
             $scope.selected_bookable_items = items
-          else
-            $scope.skipThisStep()
         else
           setPerson people
           $scope.bookable_items = items
@@ -177,13 +176,15 @@ angular.module('BB.Controllers').controller 'PersonList', ($scope, $rootScope,
   * @param {array} item Selected item from the list of current people
   * @param {string=} route A specific route to load
   ###
-  $scope.selectItem = (item, route) =>
+  $scope.selectItem = (item, route, options = {}) =>
     if $scope.$parent.$has_page_control
       $scope.person = item
       return false
     else
       new_person = getItemFromPerson(item)
       _.each $scope.booking_items, (bi) -> bi.setPerson(new_person)
+      if options.skip_step
+        $scope.skipThisStep()
       $scope.decideNextPage(route)
       return true
 

--- a/src/core/javascripts/controllers/person_list.js.coffee
+++ b/src/core/javascripts/controllers/person_list.js.coffee
@@ -113,7 +113,10 @@ angular.module('BB.Controllers').controller 'PersonList', ($scope, $rootScope,
         # if the person has been passed into item_defaults, skip to next step
         # OR if there's only 1 person and combine resources/staff has been turned on, auto select the person
         if ($scope.bb.item_defaults.person) or (items.length is 1 and $scope.bb.company.settings and $scope.bb.company.settings.merge_people)
-          if !$scope.selectItem(items[0], $scope.nextRoute, {skip_step: true})
+          selected_item = items[0]
+          if items.length isnt 1
+            selected_item = getItemFromPerson($scope.bb.item_defaults.person)
+          if !$scope.selectItem(selected_item, $scope.nextRoute, {skip_step: true})
             setPerson people
             $scope.bookable_items = items
             $scope.selected_bookable_items = items

--- a/src/core/javascripts/controllers/person_list.js.coffee
+++ b/src/core/javascripts/controllers/person_list.js.coffee
@@ -110,7 +110,7 @@ angular.module('BB.Controllers').controller 'PersonList', ($scope, $rootScope,
             $scope.person = i.item if $scope.bb.current_item.settings.person isnt -1
             $scope.selected_bookable_items = [i]
 
-        # if the person has been passed into item_defaults via query string, skip to next step
+        # if the person has been passed into item_defaults, skip to next step
         # OR if there's only 1 person and combine resources/staff has been turned on, auto select the person
         if ($scope.bb.item_defaults.person) or (items.length is 1 and $scope.bb.company.settings and $scope.bb.company.settings.merge_people)
           if !$scope.selectItem(items[0], $scope.nextRoute, {skip_step: true})

--- a/src/core/javascripts/controllers/resource_list.js.coffee
+++ b/src/core/javascripts/controllers/resource_list.js.coffee
@@ -110,9 +110,10 @@ angular.module('BB.Controllers').controller 'ResourceList', ($scope,
           if $scope.booking_item and $scope.booking_item.resource and $scope.booking_item.resource.id is i.item.id
             # set the resource unless the resource was automatically set
             $scope.resource = i.item if $scope.bb.current_item.settings.resource isnt -1
-      # if there's only one resource and single pick hasn't been enabled,
-      # automatically select the resource.
-        if resources.length is 1 and !$scope.options.allow_single_pick
+        # if the resource has been passed into item_defaults via query string, skip to next step
+        # OR if there's only one resource and single pick hasn't been enabled,
+        # automatically select the resource.
+        if ($scope.bb.item_defaults.resource or resources.length is 1) and !$scope.options.allow_single_pick
           if !$scope.selectItem(items[0].item, $scope.nextRoute, {skip_step: true})
             $scope.bookable_resources = resources
             $scope.bookable_items = items

--- a/src/core/javascripts/controllers/resource_list.js.coffee
+++ b/src/core/javascripts/controllers/resource_list.js.coffee
@@ -110,7 +110,7 @@ angular.module('BB.Controllers').controller 'ResourceList', ($scope,
           if $scope.booking_item and $scope.booking_item.resource and $scope.booking_item.resource.id is i.item.id
             # set the resource unless the resource was automatically set
             $scope.resource = i.item if $scope.bb.current_item.settings.resource isnt -1
-        # if the resource has been passed into item_defaults via query string, skip to next step
+        # if the resource has been passed into item_defaults, skip to next step
         # OR if there's only one resource and single pick hasn't been enabled,
         # automatically select the resource.
         if ($scope.bb.item_defaults.resource or resources.length is 1) and !$scope.options.allow_single_pick

--- a/src/core/javascripts/controllers/resource_list.js.coffee
+++ b/src/core/javascripts/controllers/resource_list.js.coffee
@@ -110,16 +110,16 @@ angular.module('BB.Controllers').controller 'ResourceList', ($scope,
           if $scope.booking_item and $scope.booking_item.resource and $scope.booking_item.resource.id is i.item.id
             # set the resource unless the resource was automatically set
             $scope.resource = i.item if $scope.bb.current_item.settings.resource isnt -1
-        # if the resource has been passed into item_defaults, skip to next step
-        # OR if there's only one resource and single pick hasn't been enabled,
+        # if there's only one resource and single pick hasn't been enabled,
         # automatically select the resource.
-        if ($scope.bb.item_defaults.resource or resources.length is 1) and !$scope.options.allow_single_pick
-          selected_item = items[0]
-          if resources.length isnt 1
-            selected_item = getItemFromResource($scope.bb.item_defaults.resource)
-          if !$scope.selectItem(selected_item.item, $scope.nextRoute, {skip_step: true})
-            $scope.bookable_resources = resources
-            $scope.bookable_items = items
+        # OR if the resource has been passed into item_defaults and single pick hasn't been enabled,, skip to next step
+        if resources.length is 1
+          resource = items[0]
+        if $scope.bb.item_defaults.resource
+          resource = $scope.bb.item_defaults.resource
+        if resource and !$scope.selectItem(resource.item, $scope.nextRoute, {skip_step: true})
+          $scope.bookable_resources = resources
+          $scope.bookable_items = items
         else
           $scope.bookable_resources = resources
           $scope.bookable_items = items

--- a/src/core/javascripts/controllers/resource_list.js.coffee
+++ b/src/core/javascripts/controllers/resource_list.js.coffee
@@ -114,7 +114,10 @@ angular.module('BB.Controllers').controller 'ResourceList', ($scope,
         # OR if there's only one resource and single pick hasn't been enabled,
         # automatically select the resource.
         if ($scope.bb.item_defaults.resource or resources.length is 1) and !$scope.options.allow_single_pick
-          if !$scope.selectItem(items[0].item, $scope.nextRoute, {skip_step: true})
+          selected_item = items[0]
+          if resources.length isnt 1
+            selected_item = getItemFromResource($scope.bb.item_defaults.resource)
+          if !$scope.selectItem(selected_item.item, $scope.nextRoute, {skip_step: true})
             $scope.bookable_resources = resources
             $scope.bookable_items = items
         else


### PR DESCRIPTION
**Change Notes:**
Made same changes as done for PR on version 1(https://github.com/BookingBug/bookingbug-angular/pull/541), to fix skipping person_list/resouce_list when they have been set in item_defaults.

<h3 align="center">
After:  implementing changes :
</h3>

## Screencast:
**With passing in person id:**
![](https://i.gyazo.com/82cd8d706949549cd3204affe0f52894.gif)

**Without passing in person id:**
![](https://i.gyazo.com/aaf3ecffcb66e3bfe8335a531c97eb77.gif)