### PR TITLE
[Version 1] Fixed setting 'skipped' on the 'calendar' page when it auto-skips to the next page

### DIFF
--- a/src/core/javascripts/controllers/time_range_list.js.coffee
+++ b/src/core/javascripts/controllers/time_range_list.js.coffee
@@ -497,6 +497,7 @@ angular.module('BB.Controllers').controller 'TimeRangeList',
           requested_slot = DateTimeUtilitiesService.checkDefaultTime(day.date, day.slots, current_item, $scope.bb.item_defaults)
 
           if requested_slot.slot and requested_slot.match == "full"
+            $scope.skipThisStep()
             $scope.selectSlot requested_slot.slot, day
           else if requested_slot.slot
             $scope.highlightSlot requested_slot.slot, day
@@ -505,14 +506,14 @@ angular.module('BB.Controllers').controller 'TimeRangeList',
 
          $scope.$broadcast "time_slots:loaded", time_slots
 
-      , (err) -> 
+      , (err) ->
         if err.status == 404  && err.data && err.data.error && err.data.error == "No bookable events found"
           if $scope.data_source && $scope.data_source.person
             AlertService.warning(ErrorService.getError('NOT_BOOKABLE_PERSON'))
-            $scope.setLoaded $scope        
+            $scope.setLoaded $scope
           else if  $scope.data_source && $scope.data_source.resource
             AlertService.warning(ErrorService.getError('NOT_BOOKABLE_RESOURCE'))
-            $scope.setLoaded $scope        
+            $scope.setLoaded $scope
           else
           $scope.setLoadedAndShowError($scope, err, 'Sorry, something went wrong')
         else


### PR DESCRIPTION
**Change Notes:**
Fixed setting 'skipped' on the 'calendar' page when it auto-skips to the next page, so that clicking 'Back' button on the next page(generally 'check_items' pages/'review page') behaves as expected, that is, it routes back to the 'service_list' page.

<h3 align="center">Before:  implementing changes : </h3>

![](https://i.gyazo.com/1f2e8188b82d50bd6c8f95d2527bf1a7.gif)

<h3 align="center">After:  implementing changes : </h3>

![](https://i.gyazo.com/c59153f1d1367264ffc58493decd5c4d.gif)
