### PR TITLE
Fix bbAdminBooking' over-writing rootScope (v2)

### DIFF
--- a/src/admin-booking/javascripts/directives/admin_booking.js.coffee
+++ b/src/admin-booking/javascripts/directives/admin_booking.js.coffee
@@ -35,5 +35,6 @@ angular.module('BBAdminBooking').directive 'bbAdminBooking', (BBModel, $log, $co
   {
     link: link
     controller: 'BBCtrl'
+    scope: true
   }
 


### PR DESCRIPTION
**Notes :** 
Ensure that the 'bbAdminBooking' directive creates a new child scope that prototypically inherits from the parent scope to avoid it over-writing the rootScope.

While creating a directive, 
default (scope: false) - the directive does not create a new scope.
Hence we need to set it to true.

Please see AngularJS Documentation at : https://github.com/angular/angular.js/wiki/Understanding-Scopes#directives for more information.