### PR TITLE
Fix accordion on calendar page to be consistently aligned.

### DIFF
--- a/src/public-booking/javascripts/translations/en.js.coffee
+++ b/src/public-booking/javascripts/translations/en.js.coffee
@@ -6,7 +6,7 @@ angular.module('BB.Services').config ($translateProvider) ->
   translations = {
     PUBLIC_BOOKING: {
       ACCORDION_RANGE_GROUP: {
-        AVAILABLE: '{SLOTS_NUMBER, plural, =0{no time} =1{1 time} other{{SLOTS_NUMBER} times}} available'
+        AVAILABLE: '{SLOTS_NUMBER, plural, =0{0 available} =1{1 available} other{{SLOTS_NUMBER} available}}'
       }
     }
   }


### PR DESCRIPTION
**Change Note:**
- Fixed accordion on calendar page to be consistently aligned by modifying translation value.

## Screenshot before fix:
_(Note how the accordion is inconsistently aligned when there is only 1 available time slot)_

![](https://i.gyazo.com/2a5945511791514214e480f5b6989830.png)

## Screenshot with changes implemented:
_(Note how the accordion is now consistently aligned)_

![](https://i.gyazo.com/7df4de437ed4d115b538b0f05ff8a2a8.png)