### PR TITLE
Smoothen transition between selecting a time slot and focussing on continue button.

### DIFF
--- a/src/core/javascripts/controllers/time_range_list.js.coffee
+++ b/src/core/javascripts/controllers/time_range_list.js.coffee
@@ -27,7 +27,7 @@
 ####
 
 
-angular.module('BB.Directives').directive 'bbTimeRanges', ($q, $templateCache, $compile) ->
+angular.module('BB.Directives').directive 'bbTimeRanges', ($q, $templateCache, $compile, $timeout, $bbug) ->
   restrict: 'AE'
   replace: true
   scope : true
@@ -35,11 +35,18 @@ angular.module('BB.Directives').directive 'bbTimeRanges', ($q, $templateCache, $
   transclude: true
   controller : 'TimeRangeList'
   link: (scope, element, attrs, controller, transclude) ->
-    # focus on continue button after slot selected - for screen readers 
+    # focus on continue button after slot selected - for screen readers
     scope.$on 'time:selected', ->
       btn = angular.element('#btn-continue')
       btn[0].disabled = false
-      btn[0].focus()
+      $timeout ->
+        $bbug("html, body").animate
+          scrollTop: btn.offset().top
+          , 500
+      , 1000
+      $timeout ->
+        btn[0].focus()
+      , 1500
 
     # date helpers
     scope.today = moment().toDate()


### PR DESCRIPTION
**Change Note:**
- Added a delay and scroll animation between after selecting a time slot and focussing on continue button.

## Screenshot before fix:
_(Note how the accordion seems to move up and down rapidly on selecting a time slot)_

![](https://i.gyazo.com/029e308b50f976b1363aa1fcbf828a30.gif)

## Screenshot with changes implemented:
_(Note how the transitions now seem smoother on selecting a time slot)_

![](https://i.gyazo.com/4b48c67da3d1838dfa1801208012eee4.gif)