### PR TITLE
change colour of border on focused elements to be non browser specific and consistent with input elements

### DIFF
--- a/src/public-booking/stylesheets/_buttons.scss
+++ b/src/public-booking/stylesheets/_buttons.scss
@@ -54,3 +54,17 @@
   }
 
 }
+
+.btn {
+  &:focus, &:active:focus {
+    outline: 0;
+    border: 1px $input-border-focus solid;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(red($input-border-focus), green($input-border-focus), blue($input-border-focus), .6);
+  }
+  span {
+    &:focus {
+      outline: 0;
+      border: none;
+    }
+  }
+}

--- a/src/public-booking/stylesheets/_calendar.scss
+++ b/src/public-booking/stylesheets/_calendar.scss
@@ -145,6 +145,11 @@
       background-color: $gray-darker;
       color: #FFF;
     }
+    &:focus {
+      outline: 0;
+      border: 1px $input-border-focus solid;
+      box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(red($input-border-focus), green($input-border-focus), blue($input-border-focus), .6);
+    }
   }
 
   .period-label-icon {
@@ -166,7 +171,7 @@
   .panel-default.expanded > .panel-heading {
     padding-bottom: 5px;
   }
-  
+
   .unavailable-slot {
     &:hover {
       cursor: default;
@@ -178,7 +183,9 @@
       cursor: pointer;
     }
     &:focus {
-      outline: -webkit-focus-ring-color auto 5px;
+      outline: 0;
+      border: 1px $input-border-focus solid;
+      box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(red($input-border-focus), green($input-border-focus), blue($input-border-focus), .6);
     }
   }
 
@@ -199,7 +206,9 @@
 
   .accordion-toggle {
     &:focus {
-      outline: -webkit-focus-ring-color auto 5px;
+      outline: 0;
+      border: 1px $input-border-focus solid;
+      box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(red($input-border-focus), green($input-border-focus), blue($input-border-focus), .6);
     }
   }
 

--- a/src/public-booking/stylesheets/_page.scss
+++ b/src/public-booking/stylesheets/_page.scss
@@ -22,12 +22,25 @@ ul, ol {
 
 a {
   text-decoration: underline;
+  &:focus {
+    outline: 0;
+    border: 1px $input-border-focus solid;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(red($input-border-focus), green($input-border-focus), blue($input-border-focus), .6);
+  }
 }
 
 p {
   margin-bottom: 10px; margin-bottom: 1rem;
   &:last-child {
     margin-bottom: 0;
+  }
+}
+
+div {
+  &:focus {
+    outline: 0;
+    border: 1px $input-border-focus solid;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(red($input-border-focus), green($input-border-focus), blue($input-border-focus), .6);
   }
 }
 


### PR DESCRIPTION
**Change Note:**
- Changed colour of border on focused elements to be consistent with border on focused input elements.

## Screenshot before fix:
_(Note the border colour on the focused element is browser specific, the one displayed below is on Google Chrome)_

![](https://i.gyazo.com/bedc6f5c9817b71c82553c64472eca9c.gif)

## Screenshot with changes implemented:
_(Note that the border colour on the focused element is not browser specific and is consistent with the border on a focused input element)_

![](https://i.gyazo.com/c30422d8117d3572e119b6ad91a969fc.gif)