### PR TITLE
fix book waitlist button to be in line with cancel/move booking button.

### DIFF
--- a/src/public-booking/templates/purchase.html
+++ b/src/public-booking/templates/purchase.html
@@ -82,9 +82,9 @@
                   <div class="col-sm-4">
                     <button type="button" class="btn btn-primary btn-block" ng-click="move(bookings[0], '', {use_resource: true})">Move Booking</button>
                   </div>
-                </div>
-                <div ng-show="waitlist_bookings"class="col-sm-4">
-                  <button type="button" class="btn btn-primary btn-block" ng-click="is_waitlist = true">Book Waitlist Items</button>
+                  <div ng-show="waitlist_bookings"class="col-sm-4">
+                    <button type="button" class="btn btn-primary btn-block" ng-click="is_waitlist = true">Book Waitlist Items</button>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
**Change Note:**
- Fixed `Book Waitlist Items` button to be in line with cancel/move booking button.

## Screenshot before fix:
_(Note how the `Book Waitlist Items` button is mis-aligned)_

![](https://monosnap.com/file/mUaM9mGce5QSFHGl7BFoFQxeeY0I4u.png)

## Screenshot with changes implemented:
_(Note how the `Book Waitlist Items` button is now properly aligned)_

![](https://monosnap.com/file/hiYC2mPvxobZjr9l8d90Zft4rTMyZc.png)