### PR TITLE
fix not showing booking details when booking has already been cancelled.

### DIFF
--- a/src/public-booking/templates/purchase.html
+++ b/src/public-booking/templates/purchase.html
@@ -12,7 +12,7 @@
           </div>
         </div>
 
-        <div ng-show="bookings">
+        <div ng-show="bookings && bookings.length != 0">
           <div ng-show="is_waitlist">
             <div bb-include="book_waitlist"></div>
           </div>


### PR DESCRIPTION
**Change Note:**
- Fixed not showing booking details when booking has already been cancelled.

## Screenshot before fix:
_(Note how the booking details are being incorrectly shown when booking has already been cancelled)_

![](https://monosnap.com/file/rBT7lrdtF43oNJdFXUeVHUmOvqCSbI.png)

## Screenshot with changes implemented:
_(Note how the booking details are now being hidden when booking has already been cancelled)_

![](https://monosnap.com/file/zsQaGyykRkefW3LFIuHtH6RmKutScI.png)