### PR TITLE
[CORE-168] fixed error 'Cannot read property target of 'undefined'".

### DIFF
--- a/src/admin-dashboard/javascripts/calendar/controllers/resource_calendar.controller.js.coffee
+++ b/src/admin-dashboard/javascripts/calendar/controllers/resource_calendar.controller.js.coffee
@@ -267,7 +267,7 @@ angular.module('BBAdminDashboard.calendar.controllers').controller 'bbResourceCa
       PrePostTime.apply(event, elements, view, $scope)
 
   fcSelect = (start, end, jsEvent, view, resource) -> # For some reason clicking on the scrollbars triggers this event therefore we filter based on the jsEvent target
-    if jsEvent.target.className == 'fc-scroller'
+    if jsEvent and jsEvent.target.className == 'fc-scroller'
       return
 
     view.calendar.unselect()


### PR DESCRIPTION
**Change Notes:**
- fixed error "Cannot read property 'target' of undefined" to support calling 'select_method' of FullCalendar programmatically.
Please see FullCalendar Documentation at https://fullcalendar.io/docs/selection/select_callback/.
The documentation points out that "If select has been triggered via the select method, jsEvent will be undefined".