### PR TITLE
[CORE-168] (version1) fixed error 'Cannot read property target of 'undefined'".

### DIFF
--- a/src/admin-dashboard/javascripts/calendar/directives/bbResourceCalendar.js.coffee
+++ b/src/admin-dashboard/javascripts/calendar/directives/bbResourceCalendar.js.coffee
@@ -155,7 +155,7 @@ angular.module('BBAdminDashboard.calendar.directives').directive 'bbResourceCale
         select: (start, end, jsEvent, view, resource) ->
           # For some reason clicking on the scrollbars triggers this event
           #  therefore we filter based on the jsEvent target
-          if jsEvent.target.className == 'fc-scroller'
+          if jsEvent and jsEvent.target.className == 'fc-scroller'
             return
 
           view.calendar.unselect()


### PR DESCRIPTION
**Change Notes:**
- Same changes as made for 'master' branch at https://github.com/BookingBug/bookingbug-angular/pull/613 .

**Details:**
- fixed error "Cannot read property 'target' of undefined" to support calling 'select_method' of FullCalendar programmatically.
Please see FullCalendar Documentation at https://fullcalendar.io/docs/selection/select_callback/.
The documentation points out that "If select has been triggered via the select method, jsEvent will be 'undefined'".