### PR TITLE
fix google maps to centre on open marker and respect default zoom if passed in

### DIFF
--- a/src/core/javascripts/directives/steps_directives/bb_map/bb_map.controller.js.coffee
+++ b/src/core/javascripts/directives/steps_directives/bb_map/bb_map.controller.js.coffee
@@ -157,7 +157,7 @@ angular.module('BB.Controllers').controller 'MapCtrl', ($scope, $element, $attrs
 
     $timeout ->
       $scope.myMap.fitBounds($scope.mapBounds)
-      $scope.myMap.setZoom(15)
+      $scope.myMap.setZoom($scope.default_zoom) if $scope.options.default_zoom
       if $scope.bb.current_item.service and $scope.options and $scope.filter_by_service
         loader.setLoaded()
     checkDataStore()
@@ -292,7 +292,7 @@ angular.module('BB.Controllers').controller 'MapCtrl', ($scope, $element, $attrs
     $scope.loc           = result.geometry.location
     $scope.formatted_address = result.formatted_address
     $scope.myMap.setCenter $scope.loc
-    $scope.myMap.setZoom 15
+    $scope.myMap.setZoom($scope.default_zoom) if $scope.options.default_zoom
     $scope.showClosestMarkers $scope.loc
     $rootScope.$broadcast "map:search_success"
 
@@ -438,6 +438,7 @@ angular.module('BB.Controllers').controller 'MapCtrl', ($scope, $element, $attrs
     $timeout ->
 
       $scope.currentMarker = marker
+      $scope.myMap.setCenter(marker.position)
       $scope.myInfoWindow.open($scope.myMap, marker)
       for shown_marker in $scope.shownMarkers
         if shown_marker.company.id is marker.company.id
@@ -593,7 +594,7 @@ angular.module('BB.Controllers').controller 'MapCtrl', ($scope, $element, $attrs
     if new_value != old_value and $scope.loc
       $scope.myInfoWindow.close()
       $scope.myMap.setCenter $scope.loc
-      $scope.myMap.setZoom 15
+      $scope.myMap.setZoom($scope.default_zoom) if $scope.options.default_zoom
       $scope.showClosestMarkers $scope.loc
 
 


### PR DESCRIPTION
**Change Notes:**
- fixed centring on current marker on the google map.
- fixed google maps to respect default zoom if it is passed into the directive

## Screencast before fix:
_(Note how the map is not centred  on the open marker and the default zoom is not being respected)_

![](https://i.gyazo.com/2b8fd242d2edff93b8a5e3bfe6bb7536.gif)

## Screencast with changes implemented:
_(Note how the map is now centred on the open marker and the default zoom which was set to 6 is respected)_

![](https://i.gyazo.com/876b8b75321a0f572e113e4cc689921a.gif)