### PR TITLE
[IMPL-2002] improvements for bb-map

### DIFF
--- a/src/core/javascripts/directives/bb_widget/bb_widget_init.service.js
+++ b/src/core/javascripts/directives/bb_widget/bb_widget_init.service.js
@@ -415,6 +415,7 @@
                                 return bbWidgetPage.decideNextPage(page);
                             }
                         }
+                        $scope.isLoaded = true;
                     });
                 }, function (err) {
                     connectionStarted.reject("Failed to start widget");

--- a/src/core/javascripts/directives/steps/bb_map/bb_map.controller.js
+++ b/src/core/javascripts/directives/steps/bb_map/bb_map.controller.js
@@ -55,6 +55,9 @@ angular.module('BB.Controllers').controller('MapCtrl', function ($scope, $elemen
      */
     $scope.initialise = function () {
 
+        $scope.mapMarkers = [];
+        $scope.shownMarkers = $scope.shownMarkers || [];
+
         if (!$scope.selectedStore) {
                 loader.setLoaded();
             }

--- a/src/core/javascripts/directives/steps/bb_map/bb_map.controller.js
+++ b/src/core/javascripts/directives/steps/bb_map/bb_map.controller.js
@@ -9,6 +9,7 @@ angular.module('BB.Controllers').controller('MapCtrl', function ($scope, $elemen
     // init vars
     $scope.options = $scope.$eval($attrs.bbMap) || {};
 
+    // when set to true, selectItem() does not call decideNextPage() when calling $scope.initWidget()
     $scope.no_route = $scope.options.no_route || false;
 
     $scope.num_search_results = $scope.options.num_search_results || 6;
@@ -18,7 +19,10 @@ angular.module('BB.Controllers').controller('MapCtrl', function ($scope, $elemen
     $scope.filter_by_service = $scope.options.filter_by_service || false; // The aforementioned checkbox is bound to this value which can be true or false depending on checked state, hence why we cannot use filter_by_service to show/hide the checkbox
     $scope.default_zoom = $scope.options.default_zoom || 6;
 
+    // custom map marker icon can be set using GeneralOptions
     let defaultPin = GeneralOptions.map_marker_icon
+
+    // when set to false, geolocate() only fills the input with the returned address and does not load the map
     $scope.loadMapOnGeolocate = true;
 
     let map_ready_def = $q.defer();
@@ -329,6 +333,7 @@ angular.module('BB.Controllers').controller('MapCtrl', function ($scope, $elemen
                     } else {
                         searchFailed();
                     }
+                    loader.setLoaded();
                 });
             }
         });
@@ -366,7 +371,7 @@ angular.module('BB.Controllers').controller('MapCtrl', function ($scope, $elemen
             } else {
                 searchFailed();
             }
-            return $timeout(() => loader.setLoaded());
+            return;
         });
     };
 
@@ -659,7 +664,7 @@ angular.module('BB.Controllers').controller('MapCtrl', function ($scope, $elemen
 
         $scope.loadMapOnGeolocate = loadMapOnGeolocate;
 
-        $timeout(() => loader.notLoaded());
+        loader.notLoaded();
 
         return webshim.ready('geolocation', function () {
             // set timeout as 5 seconds and max age as 1 hour

--- a/src/core/javascripts/directives/steps/bb_map/bb_map.controller.js
+++ b/src/core/javascripts/directives/steps/bb_map/bb_map.controller.js
@@ -1,4 +1,4 @@
-angular.module('BB.Controllers').controller('MapCtrl', function ($scope, $element, $attrs, $rootScope, AlertService, FormDataStoreService, LoadingService, $q, $window, $timeout, ErrorService, $log, GeolocationService) {
+angular.module('BB.Controllers').controller('MapCtrl', function ($scope, $element, $attrs, $rootScope, AlertService, FormDataStoreService, LoadingService, $q, $window, $timeout, ErrorService, $log, GeolocationService, GeneralOptions) {
 
     FormDataStoreService.init('MapCtrl', $scope, [
         'address',
@@ -18,6 +18,8 @@ angular.module('BB.Controllers').controller('MapCtrl', function ($scope, $elemen
     $scope.filter_by_service = $scope.options.filter_by_service || false; // The aforementioned checkbox is bound to this value which can be true or false depending on checked state, hence why we cannot use filter_by_service to show/hide the checkbox
     $scope.default_zoom = $scope.options.default_zoom || 6;
 
+    let defaultPin = GeneralOptions.map_marker_icon
+
     let map_ready_def = $q.defer();
     $scope.mapLoaded = $q.defer();
     $scope.mapReady = map_ready_def.promise;
@@ -27,9 +29,6 @@ angular.module('BB.Controllers').controller('MapCtrl', function ($scope, $elemen
     $scope.shownMarkers = $scope.shownMarkers || [];
     if (!$scope.numberedPin) {
         $scope.numberedPin = null;
-    }
-    if (!$scope.defaultPin) {
-        $scope.defaultPin = null;
     }
     if (!$scope.address && $attrs.bbAddress) {
         $scope.address = $scope.$eval($attrs.bbAddress);
@@ -184,7 +183,7 @@ angular.module('BB.Controllers').controller('MapCtrl', function ($scope, $elemen
                     map: $scope.myMap,
                     position: latlong,
                     visible: $scope.showAllMarkers,
-                    icon: $scope.defaultPin
+                    icon: defaultPin
                 });
                 marker.company = comp;
                 if (!$scope.hide_not_live_stores || !!comp.live) {

--- a/src/core/javascripts/services/general_options.js
+++ b/src/core/javascripts/services/general_options.js
@@ -33,7 +33,8 @@ angular.module('BB.Services').provider('GeneralOptions', function () {
         use_local_time_zone: false,
         display_time_zone: null,
         update_document_title: false,
-        scroll_offset: 0
+        scroll_offset: 0,
+        map_marker_icon: null
     };
 
 


### PR DESCRIPTION
**Change Notes:**
- ability to re-initialise the map page during runtime without reloading the page.
  - moved the functionality to initialise the map page into `$scope.initialise`
- ability to choose to stay on the same page when calling selectItem() on the map page.
  - `no_route` option which when set to true, selectItem() does not call decideNextPage() when calling $scope.initWidget().
    ```bb-map="{no_route: true}"```
- ability to set a custom map marker icon via GeneralOptionsProvider
   ```
   GeneralOptionsProvider.setOption('map_marker_icon', 'images/example_image_name.png');
   ```
-  ability to only fill in the address and not load the map when calling geolocate()
   ```
   ng-click="geolocate(false)"
   ```
- corrected `return` statements and calls to `loader.notLoaded()`, `loader.setLoaded()`.