### PR TITLE
[IMPL-2004] fix 'bb-scroll-to' to scroll correctly on a modal.

### DIFF
--- a/src/core/javascripts/services/scrollIntercepter.js
+++ b/src/core/javascripts/services/scrollIntercepter.js
@@ -23,8 +23,7 @@ angular.module('BB.Services').factory('scrollIntercepter', ($bbug, $window, Gene
 
             if ('parentIFrame' in $window) {
                 parentIFrame.scrollToOffset(0, element.offset().top - GeneralOptions.scroll_offset);
-            }
-            else if (AppService.isModalOpen()) {
+            } else if (AppService.isModalOpen()) {
                 $bbug('[uib-modal-window]').animate({
                     scrollTop: element.offset().top - GeneralOptions.scroll_offset
                 }, transitionTime);

--- a/src/core/javascripts/services/scrollIntercepter.js
+++ b/src/core/javascripts/services/scrollIntercepter.js
@@ -7,7 +7,7 @@
  *
  */
 
-angular.module('BB.Services').factory('scrollIntercepter', ($bbug, $window, GeneralOptions, $timeout) => {
+angular.module('BB.Services').factory('scrollIntercepter', ($bbug, $window, GeneralOptions, AppService, $timeout) => {
 
     var currentlyScrolling = false;
 
@@ -23,6 +23,11 @@ angular.module('BB.Services').factory('scrollIntercepter', ($bbug, $window, Gene
 
             if ('parentIFrame' in $window) {
                 parentIFrame.scrollToOffset(0, element.offset().top - GeneralOptions.scroll_offset);
+            }
+            else if (AppService.isModalOpen()) {
+                $bbug('[uib-modal-window]').animate({
+                    scrollTop: element.offset().top - GeneralOptions.scroll_offset
+                }, transitionTime);
             } else {
                 $bbug("html, body").animate({
                     scrollTop: element.offset().top - GeneralOptions.scroll_offset

--- a/src/core/javascripts/services/scrollIntercepter.js
+++ b/src/core/javascripts/services/scrollIntercepter.js
@@ -21,12 +21,13 @@ angular.module('BB.Services').factory('scrollIntercepter', ($bbug, $window, Gene
         if (!currentlyScrolling) {
             currentlyScrolling = true;
 
-            if ('parentIFrame' in $window) {
-                parentIFrame.scrollToOffset(0, element.offset().top - GeneralOptions.scroll_offset);
-            } else if (AppService.isModalOpen()) {
+            // if theres a modal open, scrolling to it takes the higest precedence
+            if (AppService.isModalOpen()) {
                 $bbug('[uib-modal-window]').animate({
                     scrollTop: element.offset().top - GeneralOptions.scroll_offset
                 }, transitionTime);
+            } else if ('parentIFrame' in $window) {
+                parentIFrame.scrollToOffset(0, element.offset().top - GeneralOptions.scroll_offset);
             } else {
                 $bbug("html, body").animate({
                     scrollTop: element.offset().top - GeneralOptions.scroll_offset


### PR DESCRIPTION
**Change Note:**
- [IMPL-2004] fix 'bb-scroll-to' to scroll correctly on a modal.

**Details:**
It was noticed that if `bb-scroll-to` was set on an element located on a page loaded inside a modal, rather than scrolling to the appropriate element, the page was scrolling in the greyed background of the modal. This was due to the code calling the scrollTop function on the wrong context(the html, body) instead of on the modal(when the modal is open).