### PR TITLE
Show/hide non-bookable services from service list using 'include_non_…

### DIFF
--- a/src/admin-booking/templates/quick_pick.html
+++ b/src/admin-booking/templates/quick_pick.html
@@ -23,7 +23,7 @@
         name="appointmentBookingForm">
 
         <div
-          bb-services="{allow_single_pick: true}"
+          bb-services="{allow_single_pick: true, include_non_bookable: false}"
           class="form-group"
           ng-class="{
             'has-error': appointmentBookingForm.service.$invalid &&


### PR DESCRIPTION
…bookable' flag. Non-bookable being services which don't have a person or resource attached to it.

*Please do not merge this PR until after merging* - https://github.com/BookingBug/bookingbug-angular/pull/695

*Question:* should non-bookable services be visible by default? In this case, they are hidden in the 'quick_pick' template.