### PR TITLE
[IMPL-2318] removed adding orphanItems to the ordered list (side_navigation).

### DIFF
--- a/src/admin-dashboard/javascripts/core/services/side_navigation_partials.js
+++ b/src/admin-dashboard/javascripts/core/services/side_navigation_partials.js
@@ -32,10 +32,7 @@ angular.module('BBAdminDashboard').factory('SideNavigationPartials', [
                 return templatesArray;
             },
 
-            getOrderedPartialTemplates(flat){
-                if (flat == null) {
-                    flat = false;
-                }
+            getOrderedPartialTemplates(flat = false){
                 let orderedList = [];
                 let flatOrderedList = [];
 
@@ -58,24 +55,6 @@ angular.module('BBAdminDashboard').factory('SideNavigationPartials', [
                         return orderedList.push(newGroup);
                     }
                 });
-
-                let orphanItems = [];
-
-                angular.forEach(templatesArray, function (partial, index) {
-                    let existing = _.find(flatOrderedList, item => item.module === partial.module);
-
-                    if (!existing) {
-                        flatOrderedList.push(partial);
-                        return orphanItems.push(partial);
-                    }
-                });
-
-                if (orphanItems.length) {
-                    orderedList.push({
-                        group_name: '&nbsp;',
-                        items: orphanItems
-                    });
-                }
 
                 if (flat) {
                     return flatOrderedList;


### PR DESCRIPTION
**Change Note:**
- [IMPL-2318] removed adding orphanItems to the ordered list (side_navigation).

**Details:**
It was noticed that the setting the `side_navigation` option in `AdminCoreOptionsProvider` as follows,
```
    AdminCoreOptionsProvider.setOption('side_navigation', [
    {
        group_name: 'SIDE_NAV_QUEUING',
        items: ['queue']
    }, {
        group_name: 'SIDE_NAV_BOOKINGS',
        items: ['calendar', 'clients']
    }, {
        group_name: 'SIDE_NAV_CONFIG',
        items: ['config-iframe', 'publish-iframe', 'settings-iframe']
    }
    ]);
```
 was not being respected since `orphanItems` were being added to the end of the array `$scope.navigation`.
