### PR TITLE
[IMPL-2317] show modal popup on clicking 'Finish Serving' only if schemaForm returns with 'Outcomes' tab.

### DIFF
--- a/src/queue/javascripts/controllers/queue_server.js
+++ b/src/queue/javascripts/controllers/queue_server.js
@@ -125,7 +125,7 @@ let QueueServerController = ($scope, $log, AdminQueueService, ModalForm, BBModel
                     person.attendance_status = 1;
                     $scope.loadingServer = false;
                 });
-            }
+            } else $scope.loadingServer = false;
         });
     };
 

--- a/src/queue/templates/queue/queue_server_actions.html
+++ b/src/queue/templates/queue/queue_server_actions.html
@@ -26,7 +26,7 @@
 </div>
 <div class="btn-group pull-right" ng-hide="loadingServer">
   <button type="button" class="btn btn-success"
-    ng-click="finishServingQueuer({person: person, outcomes: true})"
+    ng-click="finishServingQueuer({person: person})"
     ng-if="person && person.$has('finish_serving') && person.serving">
     Finish Serving
   </button>


### PR DESCRIPTION
**Change Note:**
- [IMPL-2317] show modal popup on clicking 'Finish Serving' only if schemaForm returns with 'Outcomes' tab.

**Details:**
- `Problem` : On the new Queuing Interface on Admin Studio, under the Concierge view, it was noticed that in the CYBG project, they did not have any outcomes configured on the back-end for the schema form to return with on clicking 'Finish Serving'. This would show an unnecessary modal popup irrespective of whether there are any outcomes or none.
- `Proposed solution` :
  - Ideally we should check if there are any outcomes and only show the modal popup in that case.
  - The schema form from booking.$get('edit') has this information in it.
  - This fix makes  the modal resolve schema promise-reject if there aren't any outcomes and then have the modalInstance.result section handle the alternative result.