### PR TITLE
fix copyright year to always be the current year.

### DIFF
--- a/src/admin-dashboard/javascripts/core/directives/bb_admin_dashboard.js
+++ b/src/admin-dashboard/javascripts/core/directives/bb_admin_dashboard.js
@@ -12,6 +12,8 @@ angular.module('BBAdminDashboard').directive('bbAdminDashboard', PageLayout => {
 
                     $rootScope.bb = $scope.bb;
 
+                    $scope.currentYear = moment().local().format('YYYY');
+
                     let api_url = $localStorage.getItem("api_url");
                     if (!$scope.bb.api_url && api_url) {
                         $scope.bb.api_url = api_url;

--- a/src/admin-dashboard/templates/core/layout.html
+++ b/src/admin-dashboard/templates/core/layout.html
@@ -73,7 +73,6 @@
     <div class="pull-right hidden-xs">
       <b translate="ADMIN_DASHBOARD.CORE.VERSION"></b> 2.0
     </div>
-    <strong><span translate="ADMIN_DASHBOARD.CORE.COPYRIGHT"></span> &copy; 2016 <a href="http://bookingbug.com"
-                                                                                    target="_blank">BookingBug</a>.</strong>
+    <strong><span translate="ADMIN_DASHBOARD.CORE.COPYRIGHT"></span> &copy; {{currentYear}} <a href="http://bookingbug.com" target="_blank">BookingBug</a>.</strong>
   </footer>
 </div><!-- ./wrapper -->


### PR DESCRIPTION
**Change Note:**
- fix copyright year to always be the current year.

## Screenshot before fix:
_(Note the copyright year is `2016`)_
![](https://i.gyazo.com/5ace5c4898d387e2af1616d60c422948.png)

## Screenshot with changes implemented:
_(Note the copyright year is now correctly `2017`)_
![](https://i.gyazo.com/bcc36ce4ad244147bedc57857d108480.png)